### PR TITLE
Fix for extra spaces and plugin directory name

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -97,9 +97,9 @@ Finally, run the ``make_deb`` command:
 .. code-block:: console
 
    $ ./make_deb
-   The package root directory is   : /home/ubuntu/source/foglamp-filter-scale/foglamp-filter-scale
+   The package root directory is   : /home/ubuntu/source/foglamp-filter-scale
    The FogLAMP required version    : >=1.4
-   The package will be built in    : /home/ubuntu/source/foglamp-filter-scale/foglamp-filter-scale/packages/build
+   The package will be built in    : /home/ubuntu/source/foglamp-filter-scale/packages/build
    The architecture is set as      : x86_64
    The package name is             : foglamp-filter-scale-1.0.0-x86_64
 
@@ -113,4 +113,5 @@ Cleaning the Package Folder
 ===========================
 
 Use the ``clean`` option to remove all the old packages and the files used to make the package.
+
 Use the ``cleanall`` option to remove all the packages and the files used to make the package.

--- a/make_deb
+++ b/make_deb
@@ -24,6 +24,7 @@ set -e
 architecture="none"
 plugin_type="filter"
 plugin_name="scale"
+plugin_install_dirname=${plugin_name}
 usage="$(basename "$0") {x86|arm} [help|clean|cleanall]
 This script is used to create the Debian package of FoglAMP C++ '${plugin_name}' ${plugin_type} plugin
 Arguments:
@@ -83,7 +84,7 @@ if [[ "$architecture" == "none" ]]; then
 fi
 
 # Get plugin version from plugin.cpp, grep comment: // Version
-plugin_version=`cat ${GIT_ROOT}/plugin.cpp | grep 'Version' | head -1 | tr -d ' ' | awk -F',' '{print $1}' | sed -e 's/\"//g'`
+plugin_version=`cat ${GIT_ROOT}/plugin.cpp | grep 'Version' | head -1 | tr -d ' ' | awk -F',' '{print $1}' | sed -e 's/\"//g' | sed -e 's/[[:space:]]\+//g'`
 # Get FogLAMP version dependency from foglamp_version file
 foglamp_version=`cat ${GIT_ROOT}/foglamp.version | tr -d ' ' | grep 'foglamp_version' | head -1 | sed -e 's/\(.*\)version\(.*\)/\2/g'`
 BUILD_ROOT="${GIT_ROOT}/packages/build"
@@ -136,8 +137,8 @@ sed -i "s/Depends: foglamp/Depends: foglamp (${foglamp_version})/g" DEBIAN/contr
 
 mkdir -p usr/local/foglamp
 cd usr/local/foglamp
-mkdir -p "plugins/${plugin_type}/${plugin_name}"
-cp -R --preserve=links ${GIT_ROOT}/build/lib*.so* "plugins/${plugin_type}/${plugin_name}"
+mkdir -p "plugins/${plugin_type}/${plugin_install_dirname}"
+cp -R --preserve=links ${GIT_ROOT}/build/lib*.so* "plugins/${plugin_type}/${plugin_install_dirname}"
 echo "Done."
 
 # Build the package


### PR DESCRIPTION
Fix for extra spaces and plugin directory name

The plugin directory name is not required but makes this script similar to other ones.